### PR TITLE
fix the status bar color for api 21-22

### DIFF
--- a/bandyer-android-design/src/main/res/values-v21/themes.xml
+++ b/bandyer-android-design/src/main/res/values-v21/themes.xml
@@ -16,9 +16,11 @@
   -->
 
 <resources>
+    <style name="BandyerSDKDesign.Theme.Base" parent="BandyerSDKDesign.Theme.Base.V16">
+        <item name="android:statusBarColor">@android:color/black</item>
+    </style>
 
     <style name="BandyerSDKDesign.ToolBarShadow" parent="">
         <item name="android:visibility">gone</item>
     </style>
-
 </resources>

--- a/bandyer-android-design/src/main/res/values-v23/themes.xml
+++ b/bandyer-android-design/src/main/res/values-v23/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="BandyerSDKDesign.Theme.Base" parent="BandyerSDKDesign.Theme.Base.V16">
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+    </style>
+</resources>

--- a/bandyer-android-design/src/main/res/values/themes.xml
+++ b/bandyer-android-design/src/main/res/values/themes.xml
@@ -16,7 +16,7 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="BandyerSDKDesign.Theme.Base" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="BandyerSDKDesign.Theme.Base.V16" parent="Theme.MaterialComponents.DayNight.NoActionBar">
 
         <item name="fontFamily">@font/bandyer_font</item>
         <item name="android:fontFamily">@font/bandyer_font</item>
@@ -39,10 +39,11 @@
 
         <item name="elevationOverlayEnabled">false</item>
         <item name="toolbarStyle">@style/BandyerSDKDesign.ToolBarStyle</item>
-        <item name="android:statusBarColor" tools:targetApi="lollipop">?attr/colorPrimaryVariant</item>
         <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
         <item name="android:enforceStatusBarContrast" tools:targetApi="q">false</item>
     </style>
+
+    <style name="BandyerSDKDesign.Theme.Base" parent="BandyerSDKDesign.Theme.Base.V16"/>
 
     <style name="BandyerSDKDesign.ToolBarStyle" parent="Widget.MaterialComponents.Toolbar.Primary">
         <item name="android:textColor">?attr/colorOnPrimary</item>

--- a/demo_app/build.gradle
+++ b/demo_app/build.gradle
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         applicationId "com.bandyer.demo_sdk_design"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/demo_app/src/main/res/values-v23/themes.xml
+++ b/demo_app/src/main/res/values-v23/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="BaseDesignDemoApp" parent="BaseDesignDemoApp.V21">
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+    </style>
+</resources>

--- a/demo_app/src/main/res/values/themes.xml
+++ b/demo_app/src/main/res/values/themes.xml
@@ -16,17 +16,19 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="BaseDesignDemoApp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="BaseDesignDemoApp.V21" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorSecondary">@color/bandyer_colorSecondary</item>
         <item name="colorOnSecondary">@color/bandyer_colorOnSecondary</item>
         <item name="colorError">@color/bandyer_colorError</item>
-        <item name="android:statusBarColor" tools:targetApi="lollipop">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">@android:color/black</item>
         <item name="colorControlNormal">?attr/colorOnPrimary</item>
         <item name="fontFamily">@font/bandyer_font</item>
         <item name="android:fontFamily">@font/bandyer_font</item>
         <item name="elevationOverlayEnabled">false</item>
         <item name="toolbarStyle">@style/BandyerSDKDesign.ToolBarStyle</item>
     </style>
+
+    <style name="BaseDesignDemoApp" parent="BaseDesignDemoApp.V21"/>
 
     <style name="DesignDemoApp" parent="BaseDesignDemoApp">
         <item name="colorPrimary">@color/bandyer_colorPrimary</item>


### PR DESCRIPTION
This fix the status bar for api 21-22, I decided to keep api 16 as the base version of the design theme.xml since themes-21.xml was already existing, and I didn't want to remove the support for lower api (even if we officially no longer support them)