### PR TITLE
Fix missing declaration of smart glass action button gravity

### DIFF
--- a/bandyer-android-design/src/main/res/values/action_button.xml
+++ b/bandyer-android-design/src/main/res/values/action_button.xml
@@ -48,6 +48,7 @@
 
     <style name="BandyerSDKDesign.ActionButton.RootLayout.SmartGlass" parent="BandyerSDKDesign.ActionButton.RootLayout">
         <item name="android:clickable">true</item>
+        <item name="android:gravity">center</item>
         <item name="android:background">?attr/selectableItemBackground</item>
         <item name="android:paddingTop">@dimen/bandyer_dimen_space0</item>
         <item name="android:paddingBottom">@dimen/bandyer_dimen_space0</item>


### PR DESCRIPTION
The BandyerSDKDesign.ActionButton.RootLayout.SmartGlass style is missing gravity declaration to center button and label inside smart glass action button ui