### PR TITLE
Dismiss dialog at rotation time if the container activity is not retaining config changes

### DIFF
--- a/bandyer-android-design/src/main/java/com/bandyer/sdk_design/smartglass/call/menu/SmartGlassActionItemMenu.kt
+++ b/bandyer-android-design/src/main/java/com/bandyer/sdk_design/smartglass/call/menu/SmartGlassActionItemMenu.kt
@@ -14,12 +14,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.fragment.app.DialogFragment
 import com.bandyer.sdk_design.R
-import com.bandyer.sdk_design.bottom_sheet.items.ActionItem
 import com.bandyer.sdk_design.call.bottom_sheet.items.CallAction
 import com.bandyer.sdk_design.extensions.getCallThemeAttribute
 import com.bandyer.sdk_design.extensions.getSmartGlassMenuDialogAttribute
-import com.bandyer.sdk_design.extensions.getTextEditorDialogAttribute
-import java.util.*
 
 /**
  * A smart glass swipeable menu widget. Selection happens with a tap on the desired item, dismiss happens with a swipe down gesture
@@ -73,6 +70,10 @@ class SmartGlassActionItemMenu : DialogFragment() {
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (savedInstanceState != null) {
+            dismiss()
+            return
+        }
         setStyle(STYLE_NO_TITLE, requireContext().getCallThemeAttribute(R.styleable.BandyerSDKDesign_Theme_Call_bandyer_smartGlassDialogMenuStyle))
     }
 


### PR DESCRIPTION
If the container activity retains config changes the dialog is not dismissed and  its UI is adapted to the new available bounds.
If the activity does not retain config changes with this fix the dialog will dismiss itself. 
We are not able to retain its instance at the moment because a selection listener referenced to the previous context cannot be updated. Furthermore we cannot retain a smart glass action item dialog because the action items referenced in it are keeping a ref to the previous activity as the ActionItem constructor always ask for a context.