### PR TITLE
Prevent null pointer exception when call bottom sheet is destroyed while in setup process

### DIFF
--- a/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/bottom_sheet/CallBottomSheet.kt
+++ b/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/bottom_sheet/CallBottomSheet.kt
@@ -242,6 +242,11 @@ open class CallBottomSheet<T>(val context: AppCompatActivity,
         val firstItem = recyclerView?.layoutManager?.getChildAt(0)
 
         firstItem?.post {
+            bottomSheetBehaviour ?: kotlin.run {
+                dispose()
+                return@post
+            }
+
             val oneLineHeight = (lineView?.getHeightWithVerticalMargin() ?: 0) +
                     (titleView?.getHeightWithVerticalMargin() ?: 0) +
                     firstItem.getHeightWithVerticalMargin() +  (firstItem.paddingTop.takeIf { callActionItems.size > MAX_ITEMS_PER_ROW } ?: 0)


### PR DESCRIPTION
Dispose call bottom sheet if it is destroyed before setup process is completed and prevent null pointer exception because bottomSheetBehaviour is null in this use case.