### PR TITLE
Fix item decoration not applied after audio controls collapsed in BandyerCallActionWidget

### DIFF
--- a/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
+++ b/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
@@ -82,6 +82,15 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
      * Optional item decoration to be added on action items' recycler view
      */
     var itemDecoration: RecyclerView.ItemDecoration? = null
+        set(value) {
+            if (value != null) {
+                field = value
+                currentShownBottomSheet?.let { addItemDecoration(it) }
+                return
+            }
+            currentShownBottomSheet?.let { removeItemDecoration(it) }
+            field = null
+        }
 
     /**
      * Sliding listener for when the widget has been slided
@@ -181,7 +190,7 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
             currentShownBottomSheet = bottomSheet as BaseBandyerBottomSheet
             anchorViews()
             (bottomSheet as? CallBottomSheet<*>)?.updateAudioRouteIcon(mCurrentAudioRoute)
-            addItemDecoration()
+            addItemDecoration(bottomSheet)
         }
 
         override fun onHide(bottomSheet: BandyerBottomSheet) {
@@ -193,7 +202,7 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
                 }
                 is RingingBottomSheet<*> -> disposeBottomSheet(bottomSheet)
             }
-            itemDecoration?.let { bottomSheet.recyclerView?.removeItemDecoration(it) }
+            removeItemDecoration(bottomSheet)
             onHiddenListener?.onHidden()
             onHiddenListener = null
         }
@@ -576,13 +585,12 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
         callBottomSheet?.collapse()
     }
 
-    private fun addItemDecoration() {
-        if (itemDecoration == null
-            || currentBottomSheetLayout == null
-            || currentBottomSheetLayout!!.recyclerView == null
-            || currentBottomSheetLayout!!.recyclerView!!.itemDecorationCount > 0) return
-        currentBottomSheetLayout!!.recyclerView!!.addItemDecoration(itemDecoration!!)
-    }
+    private fun addItemDecoration(bottomSheet: BandyerBottomSheet) = itemDecoration
+            ?.takeIf { bottomSheet.recyclerView?.itemDecorationCount == 0 }
+            ?.let { bottomSheet.recyclerView!!.addItemDecoration(it) }
+
+    private fun removeItemDecoration(bottomSheet: BandyerBottomSheet) =
+        itemDecoration?.let { bottomSheet.recyclerView?.removeItemDecoration(it) }
 
     /**
      * Add an audioRoute item to the list of available routes

--- a/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
+++ b/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
@@ -655,7 +655,7 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
 
     private fun createRingingBottomSheet(bottomSheetLayoutType: BottomSheetLayoutType) {
         if (bottomSheetLayoutType != ringingBottomSheet?.bottomSheetLayoutType)
-            disposeBottomSheet(callBottomSheet)
+            disposeBottomSheet(ringingBottomSheet)
         else return
         ringingBottomSheet = RingingBottomSheet(
             context,

--- a/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
+++ b/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
@@ -578,8 +578,8 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
     }
 
     private fun addItemDecoration() = itemDecoration?.let {
-        if (currentBottomSheetLayout!!.recyclerView!!.itemDecorationCount == 0)
-            currentBottomSheetLayout!!.recyclerView!!.addItemDecoration(it)
+        currentBottomSheetLayout!!.recyclerView!!.removeItemDecoration(it)
+        currentBottomSheetLayout!!.recyclerView!!.addItemDecoration(it)
     }
 
     /**

--- a/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
+++ b/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
@@ -192,6 +192,7 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
                 }
                 is RingingBottomSheet<*> -> disposeBottomSheet(bottomSheet)
             }
+            itemDecoration?.let { bottomSheet.recyclerView?.removeItemDecoration(it) }
             onHiddenListener?.onHidden()
             onHiddenListener = null
         }
@@ -577,9 +578,17 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
         callBottomSheet?.collapse()
     }
 
-    private fun addItemDecoration() = itemDecoration?.let {
-        currentBottomSheetLayout!!.recyclerView!!.removeItemDecoration(it)
-        currentBottomSheetLayout!!.recyclerView!!.addItemDecoration(it)
+    private fun addItemDecoration() {
+        if (itemDecoration == null
+            || currentBottomSheetLayout == null
+            || currentBottomSheetLayout!!.recyclerView == null) return
+
+        val currentRecyclerView = currentBottomSheetLayout!!.recyclerView!!
+        (0 until currentRecyclerView.itemDecorationCount).map {
+            currentRecyclerView.getItemDecorationAt(it)
+        }.firstOrNull { it == itemDecoration } ?: kotlin.run {
+            currentRecyclerView.addItemDecoration(itemDecoration!!)
+        }
     }
 
     /**

--- a/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
+++ b/bandyer-android-design/src/main/java/com/bandyer/sdk_design/call/widgets/BandyerCallActionWidget.kt
@@ -181,6 +181,7 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
             currentShownBottomSheet = bottomSheet as BaseBandyerBottomSheet
             anchorViews()
             (bottomSheet as? CallBottomSheet<*>)?.updateAudioRouteIcon(mCurrentAudioRoute)
+            addItemDecoration()
         }
 
         override fun onHide(bottomSheet: BandyerBottomSheet) {
@@ -530,7 +531,6 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
         createCallBottomSheet(bottomSheetLayoutType!!)
         isHidden = false
         currentBottomSheetLayout = callBottomSheet?.bottomSheetLayoutContent
-        addItemDecoration()
         disposeBottomSheet(ringingBottomSheet)
         disposeBottomSheet(audioRouteBottomSheet)
         this.collapsible = collapsible
@@ -549,7 +549,6 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
         createRingingBottomSheet(bottomSheetLayoutType!!)
         isHidden = false
         currentBottomSheetLayout = ringingBottomSheet?.bottomSheetLayoutContent
-        addItemDecoration()
         ringingBottomSheet?.bottomSheetLayoutContent?.id = R.id.bandyer_id_bottom_sheet_ringing
         if (callBottomSheet?.isVisible() == true || audioRouteBottomSheet?.isVisible() == true) {
             disposeBottomSheet(callBottomSheet)
@@ -569,7 +568,6 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
         audioRouteBottomSheet?.bottomSheetLayoutContent?.id = R.id.bandyer_id_bottom_sheet_audio_route
         callBottomSheet?.hide(true)
         currentBottomSheetLayout = audioRouteBottomSheet?.bottomSheetLayoutContent
-        addItemDecoration()
         audioRouteBottomSheet?.show()
     }
 
@@ -581,14 +579,9 @@ class BandyerCallActionWidget<T, F>(val context: AppCompatActivity, val coordina
     private fun addItemDecoration() {
         if (itemDecoration == null
             || currentBottomSheetLayout == null
-            || currentBottomSheetLayout!!.recyclerView == null) return
-
-        val currentRecyclerView = currentBottomSheetLayout!!.recyclerView!!
-        (0 until currentRecyclerView.itemDecorationCount).map {
-            currentRecyclerView.getItemDecorationAt(it)
-        }.firstOrNull { it == itemDecoration } ?: kotlin.run {
-            currentRecyclerView.addItemDecoration(itemDecoration!!)
-        }
+            || currentBottomSheetLayout!!.recyclerView == null
+            || currentBottomSheetLayout!!.recyclerView!!.itemDecorationCount > 0) return
+        currentBottomSheetLayout!!.recyclerView!!.addItemDecoration(itemDecoration!!)
     }
 
     /**


### PR DESCRIPTION
This fix come to your aid when the item decoration applied to BandyerCallActionWidget keeps a reference to the current shown recyclerview in the widget. 
Prior to this fix an item decoration added to the BandyerCallActionWidget and referencing  the recyclerview itself was keeping a reference to the wrong recyclerview after switching call controls, audio controls or ringing controls.
With this fix has been also fixed the capability of adding more item decoration from outside widget and keeping the itemDecoration set to the BandyerCallActionWidget variable working.