### PR TITLE
Fix call notification api 31

### DIFF
--- a/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
+++ b/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
@@ -85,7 +85,7 @@ class CallNotification {
         val channelName: String,
         val type: Type,
         var isHighImportance: Boolean = false,
-        var enableCallStyle: Boolean = false,
+        var enableCallStyle: Boolean = true,
         var color: Int? = null,
         var smallIconResource: Int? = null,
         var user: String? = null,

--- a/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
+++ b/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
@@ -373,7 +373,7 @@ class CallNotification {
                     else -> {
                         val declineAction = Notification.Action.Builder(
                             Icon.createWithResource(context, R.drawable.ic_kaleyra_decline),
-                            context.getString(R.string.kaleyra_notification_decline),
+                            context.getString(R.string.kaleyra_notification_hangup),
                             declineIntent
                         ).build()
                         builder.setActions(declineAction)

--- a/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
+++ b/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
@@ -30,7 +30,6 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.kaleyra.collaboration_suite_core_ui.R
-import com.kaleyra.collaboration_suite_core_ui.utils.DeviceUtils
 import com.kaleyra.collaboration_suite_core_ui.utils.PendingIntentExtensions
 import com.kaleyra.collaboration_suite_utils.HostAppInfo
 

--- a/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
+++ b/collaboration-suite-core-ui/src/main/java/com/kaleyra/collaboration_suite_core_ui/notification/CallNotification.kt
@@ -368,7 +368,7 @@ class CallNotification {
                             context.getString(R.string.kaleyra_notification_decline),
                             declineIntent
                         ).build()
-                        builder.setActions(answerAction, declineAction)
+                        builder.setActions(declineAction, answerAction)
                     }
                     else -> {
                         val declineAction = Notification.Action.Builder(

--- a/collaboration-suite-core-ui/src/test/java/com/kaleyra/collaboration_suite_core_ui/Iso8601Test.kt
+++ b/collaboration-suite-core-ui/src/test/java/com/kaleyra/collaboration_suite_core_ui/Iso8601Test.kt
@@ -53,9 +53,11 @@ class Iso8601Test {
     fun testNowISO8601() {
         val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         df.timeZone = TimeZone.getTimeZone("UTC")
-        val expected = df.format(Calendar.getInstance().time)
-        val result = Iso8601.nowISO8601()
-        assertEquals(expected, result)
+        val nowIso8601 = Iso8601.nowISO8601()
+        val nowIso8601Millis = Iso8601.getISO8601TstampInMillis(nowIso8601)
+        val iso8601Date = Date(nowIso8601Millis)
+        val expected = df.format(iso8601Date)
+        assertEquals(expected, nowIso8601)
     }
 
     @Test


### PR DESCRIPTION
- fix decline text shown on ongoing call notification instead of hang up on android >= 31
- fix call style not applied by default on android >= 31 call notifications
- fix decline/answer call notification actions order on ndroid >= 31 ongoing calls when call style is disabled